### PR TITLE
Fix piece display after AI move

### DIFF
--- a/backend/api/routes.py
+++ b/backend/api/routes.py
@@ -85,6 +85,7 @@ def move_piece():
         response_data = {
             'status': 'success',
             'board': new_board_string,
+            'pieces': board.to_piece_list(),
             'message': '移动成功',
             'game_over': move_result['game_over'],
             'winner': move_result['winner']
@@ -113,6 +114,7 @@ def init_board():
         return jsonify({
             'status': 'success',
             'board': board_string,
+            'pieces': board.to_piece_list(),
             'message': '棋盘初始化成功'
         })
         

--- a/backend/chess_engine/ai_suggestion.py
+++ b/backend/chess_engine/ai_suggestion.py
@@ -233,6 +233,7 @@ class AIChessSuggestionEngine:
                 'message': f'{player}方AI移动完成',
                 'original_board': board_state,
                 'new_board': new_board_state,
+                'pieces': board.to_piece_list(),
                 'move_executed': best_move,
                 'move_description': suggestion_result['suggestions'][0]['description'],
                 'frequency': suggestion_result['suggestions'][0]['frequency'],

--- a/backend/chess_engine/board.py
+++ b/backend/chess_engine/board.py
@@ -135,6 +135,18 @@ class ChessBoard:
                 board_positions[pos_index] = f"{x:01d}{y:01d}"
 
         return "".join(board_positions)
+
+    def to_piece_list(self):
+        """返回当前棋子的简单列表，用于前端显示"""
+        piece_list = []
+        for p in self.pieces:
+            piece_list.append({
+                'name': p['name'],
+                'x': p['x'],
+                'y': p['y'],
+                'type': p['type']
+            })
+        return piece_list
     
     def load_from_string(self, board_string):
         # 从180字符的棋盘状态字符串加载棋盘（与spark_chess_analysis.py兼容）

--- a/frontend/src/composables/useChessGame.js
+++ b/frontend/src/composables/useChessGame.js
@@ -29,7 +29,7 @@ export function useChessGame() {
       const response = await chessAPI.initBoard()
       if (response.status === 'success') {
         boardString.value = response.board
-        parseBoardString(response.board)
+        parseBoardString(response.board, response.pieces)
         currentPlayer.value = 'red'
         selectedPiece.value = null
         gameOver.value = false
@@ -48,12 +48,29 @@ export function useChessGame() {
   }
 
   // 解析棋盘字符串（180字符格式：9列×10行×2字符每位置）
-  const parseBoardString = (boardStr) => {
+  const parseBoardString = (boardStr, pieceData = null) => {
     pieces.length = 0
 
+    if (pieceData && Array.isArray(pieceData)) {
+      pieceData.forEach(p => {
+        const isRed = p.type === 'red'
+        pieces.push({
+          id: `${p.type}_${p.x}_${p.y}`,
+          name: p.name,
+          x: p.x,
+          y: p.y,
+          type: p.type,
+          color: isRed ? '#d32f2f' : '#1976d2',
+          bgcolor: isRed ? '#ffebee' : '#e3f2fd',
+          bgColor_b: isRed ? '#d32f2f' : '#1976d2'
+        })
+      })
+      return
+    }
+
     // 验证棋盘字符串长度
-    if (boardStr.length !== 180) {
-      console.error('棋盘字符串长度错误，期望180字符，实际:', boardStr.length)
+    if (!boardStr || boardStr.length !== 180) {
+      console.error('棋盘字符串长度错误，期望180字符，实际:', boardStr ? boardStr.length : 0)
       return
     }
 
@@ -165,7 +182,7 @@ export function useChessGame() {
         console.log('DEBUG movePiece: 移动前棋子数量:', pieces.length)
 
         boardString.value = response.board
-        parseBoardString(response.board)
+        parseBoardString(response.board, response.pieces)
 
         console.log('DEBUG movePiece: 解析后棋子数量:', pieces.length)
 
@@ -243,7 +260,7 @@ export function useChessGame() {
 
         // 更新棋盘状态
         boardString.value = response.new_board
-        parseBoardString(response.new_board)
+        parseBoardString(response.new_board, response.pieces)
 
         console.log('DEBUG makeAIMove: 更新后棋子数量:', pieces.length)
 


### PR DESCRIPTION
## Summary
- send piece list along with board data from backend
- track piece info on frontend without guessing
- expose helper to return current piece list

## Testing
- `python3 -m py_compile backend/chess_engine/board.py backend/chess_engine/ai_suggestion.py backend/api/routes.py`
- `npm install`
- `npm run build` *(fails: `type-check` exited with 2)*

------
https://chatgpt.com/codex/tasks/task_b_684243e30f64832a8090885d2b3c6a69